### PR TITLE
Upgrade to Crystal v0.30.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,5 +11,7 @@ license: MIT
 
 dependencies:
   i18n:
-    github: TechMagister/i18n.cr
-    version: 0.2.0
+    # github: TechMagister/i18n.cr
+    # version: 0.2.0
+    github: bcardiff/i18n.cr
+    branch: crystal/v0.30.0


### PR DESCRIPTION
In order to migrate to Crystal v0.30.0 with no warnings the highlighted dependency needs to be upgraded after the following PR is merged/released:

* https://github.com/TechMagister/i18n.cr/pull/18

Note: The lastest i18n.cr version is 0.3.0 and there are a couple of changes that might affect other aspects of the code.

Disclaimer: Do not use my forks as dependencies.
